### PR TITLE
Serialization checking fails with +E in a number

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -528,7 +528,7 @@ function is_serialized( $data, $strict = true ) {
 		case 'i':
 		case 'd':
 			$end = $strict ? '$' : '';
-			return (bool) preg_match( "/^{$token}:[0-9.E-]+;$end/", $data );
+			return (bool) preg_match( "/^{$token}:[0-9.+E-]+;$end/", $data );
 	}
 	return false;
 }


### PR DESCRIPTION
The {{{is_serialized()}}} function does not properly handle [0-9.]+E in scientific notation.

Issue #46570