### PR TITLE
Set CSP header equivalent to X-Frame-Options SAMEORIGIN

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5839,6 +5839,7 @@ function wp_find_hierarchy_loop_tortoise_hare( $callback, $start, $override = ar
  */
 function send_frame_options_header() {
 	header( 'X-Frame-Options: SAMEORIGIN' );
+	header( 'Content-Security-Policy: frame-ancestors \'self\';' );
 }
 
 /**


### PR DESCRIPTION
X-Frame-Options header is deprecated and replaced with the CSP header frame-ancestors
directive. Both headers must be included for maximum security benefit with older browsers.

Issue #29429