### PR TITLE
Changed wp_default_styles() and wp_default_scripts() to not use pass-…

### DIFF
--- a/src/wp-admin/includes/noop.php
+++ b/src/wp-admin/includes/noop.php
@@ -55,7 +55,7 @@ function did_action() {}
 /**
  * @ignore
  */
-function do_action_ref_array() {}
+function do_action() {}
 
 /**
  * @ignore

--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -143,9 +143,9 @@ class WP_Scripts extends WP_Dependencies {
 		 *
 		 * @since 2.6.0
 		 *
-		 * @param WP_Scripts $this WP_Scripts instance (passed by reference).
+		 * @param WP_Scripts $this WP_Scripts instance.
 		 */
-		do_action_ref_array( 'wp_default_scripts', array( &$this ) );
+		do_action( 'wp_default_scripts', $this );
 	}
 
 	/**

--- a/src/wp-includes/class.wp-styles.php
+++ b/src/wp-includes/class.wp-styles.php
@@ -111,9 +111,9 @@ class WP_Styles extends WP_Dependencies {
 		 *
 		 * @since 2.6.0
 		 *
-		 * @param WP_Styles $this WP_Styles instance (passed by reference).
+		 * @param WP_Styles $this WP_Styles instance.
 		 */
-		do_action_ref_array( 'wp_default_styles', array( &$this ) );
+		do_action( 'wp_default_styles', $this );
 	}
 
 	/**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -41,7 +41,7 @@ require( ABSPATH . WPINC . '/functions.wp-styles.php' );
  *
  * @param WP_Scripts $scripts WP_Scripts object.
  */
-function wp_register_tinymce_scripts( &$scripts, $force_uncompressed = false ) {
+function wp_register_tinymce_scripts( WP_Scripts $scripts, $force_uncompressed = false ) {
 	global $tinymce_version, $concatenate_scripts, $compress_scripts;
 	$suffix     = wp_scripts_get_suffix();
 	$dev_suffix = wp_scripts_get_suffix( 'dev' );
@@ -73,7 +73,7 @@ function wp_register_tinymce_scripts( &$scripts, $force_uncompressed = false ) {
  *
  * @param WP_Scripts $scripts WP_Scripts object.
  */
-function wp_default_packages_vendor( &$scripts ) {
+function wp_default_packages_vendor( WP_Scripts $scripts ) {
 	global $wp_locale;
 
 	$suffix = wp_scripts_get_suffix();
@@ -170,7 +170,7 @@ function wp_default_packages_vendor( &$scripts ) {
  * @param array      $tests   Features to detect.
  * @return string Conditional polyfill inline script.
  */
-function wp_get_script_polyfill( &$scripts, $tests ) {
+function wp_get_script_polyfill( WP_Scripts $scripts, $tests ) {
 	$polyfill = '';
 	foreach ( $tests as $test => $handle ) {
 		if ( ! array_key_exists( $handle, $scripts->registered ) ) {
@@ -220,7 +220,7 @@ function wp_get_script_polyfill( &$scripts, $tests ) {
  *
  * @param WP_Scripts $scripts WP_Scripts object.
  */
-function wp_default_packages_scripts( &$scripts ) {
+function wp_default_packages_scripts( WP_Scripts $scripts ) {
 	$suffix = wp_scripts_get_suffix();
 
 	$packages_versions = array(
@@ -527,7 +527,7 @@ function wp_default_packages_scripts( &$scripts ) {
  *
  * @param WP_Scripts $scripts WP_Scripts object.
  */
-function wp_default_packages_inline_scripts( &$scripts ) {
+function wp_default_packages_inline_scripts( WP_Scripts $scripts ) {
 	global $wp_locale;
 
 	if ( isset( $scripts->registered['wp-api-fetch'] ) ) {
@@ -783,7 +783,7 @@ function wp_tinymce_inline_scripts() {
  *
  * @param WP_Scripts $scripts WP_Scripts object.
  */
-function wp_default_packages( &$scripts ) {
+function wp_default_packages( WP_Scripts $scripts ) {
 	wp_default_packages_vendor( $scripts );
 	wp_register_tinymce_scripts( $scripts );
 	wp_default_packages_scripts( $scripts );
@@ -841,7 +841,7 @@ function wp_scripts_get_suffix( $type = '' ) {
  *
  * @param WP_Scripts $scripts WP_Scripts object.
  */
-function wp_default_scripts( &$scripts ) {
+function wp_default_scripts( WP_Scripts $scripts ) {
 	$suffix     = wp_scripts_get_suffix();
 	$dev_suffix = wp_scripts_get_suffix( 'dev' );
 	$guessurl   = site_url();
@@ -1877,7 +1877,7 @@ function wp_default_scripts( &$scripts ) {
  *
  * @param WP_Styles $styles
  */
-function wp_default_styles( &$styles ) {
+function wp_default_styles( WP_Styles $styles ) {
 	include( ABSPATH . WPINC . '/version.php' ); // include an unmodified $wp_version
 
 	if ( ! defined( 'SCRIPT_DEBUG' ) ) {


### PR DESCRIPTION
…by-ref

Changes to the minimum version of PHP allow for allowing just passing of
an object around as-is instead of pass-by-ref. Switched to `do_action()` as
part of the change for both `WP_Styles` and `WP_Scripts`.

Trac Issue #44979