### PR TITLE
Trac Issue #47752 - .srt files will not upload

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2735,6 +2735,12 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 				$type = false;
 				$ext  = false;
 			}
+		} elseif ( 'text/html' === $real_mime ) {
+			// Subrip text files can optionally contain HTML tags
+			if ( 'srt' !== $ext ) {
+				$type = false;
+				$ext  = false;
+			}
 		} elseif ( 'text/rtf' === $real_mime ) {
 			// Special casing for RTF files.
 			if ( ! in_array(

--- a/tests/phpunit/data/uploads/test.srt
+++ b/tests/phpunit/data/uploads/test.srt
@@ -1,0 +1,61 @@
+0
+00:00:00,1 --> 00:00:04
+HTML5 &lt;video&gt; and &lt;audio&gt; was supposed to be awesome, powerful, and fun.
+
+1
+00:00:04 --> 00:00:07
+But browser vendors couldn't agree on a codec
+
+2
+00:00:07 --> 00:00:10
+and older browsers don't support &lt;video&gt; at all.
+
+3
+00:00:10 --> 00:00:12
+This means &lt;video src="myfile.mp4" /&gt; doesn't work ...
+
+4
+00:00:12 --> 00:00:14
+until now.
+
+5
+00:00:14 --> 00:00:18
+Introducing MediaElement.js, an HTML5 &lt;video&gt; and &lt;audio&gt; player
+
+6
+00:00:18 --> 00:00:21
+that looks and works the same in every browser (even iPhone and Android).
+
+7
+00:00:21 --> 00:00:24
+For older browsers, it has custom Flash and Silverlight plugins 
+
+8
+00:00:24 --> 00:00:27
+that fully replicate the HTML5 MediaElement API
+
+9
+00:00:27 --> 00:00:30
+so you can build a consistent control UI using just HTML and CSS.
+
+10
+00:00:30 --> 00:00:33
+MediaElement.js even supports newer standards 
+
+11
+00:00:33 --> 00:00:36
+like the &lt;track&gt; element that enables the subtitles you're reading right now.
+
+12
+00:00:36 --> 00:00:39
+The subtitles can even be translated into any language using Google's Translation API.
+
+13
+00:00:39 --> 00:00:42
+As a bonus, the Flash and Silverlight fallbacks allow you to use FLV and WMV files.
+
+14
+00:00:42 --> 00:00:45
+Hope you like it. 
+
+Come follow me at <a href="http://twitter.com/johndyer">twitter.com/johndyer</a>

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1384,6 +1384,16 @@ class Tests_Functions extends WP_UnitTestCase {
 							'proper_filename' => false,
 						),
 					),
+					array(
+						DIR_TESTDATA . '/uploads/test.srt',
+						'test.srt',
+						array(
+							'ext'             => 'srt',
+							'type'            => 'text/plain',
+							'proper_filename' => false,
+						),
+					),
+
 				)
 			);
 		}


### PR DESCRIPTION
Allows for `.srt` files to be uploaded that resolve as _text/html_ depending on how fileinfo is configured for the host system.